### PR TITLE
feat: Multiple robots per TCP connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ builder:
 .PHONY: builder
 
 clean:
-	@rm -rf build_Linux *.AppImage *.zsync AppDir appimage-build __pycache__
+	@rm -rf build_Linux *.AppImage *.zsync AppDir appimage-build __pycache__ build
 
 TAG?=
 tag: ## tag the repo


### PR DESCRIPTION
This PR adds support for managing multiple robots over a single TCP socket.

By sending a `new_robot:{x}:{y}:{angleDegrees}` message, it is possible to spawn a
 new robot. An unique identifier is generated for that robot which is answered when then `new_robot` message is processed.

All robots instructions must now be suffixed with the robot uuid so `avance:{robot_uuid}` will order the {robot_uuid} to move forward.

This way you can manage multiple robots.

When a socket gets closed, all robots initiated from that connection are deleted.

